### PR TITLE
Add psycopg2 and psycopg2-binary as extra dependency options

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ with or without the `psycopg2` dependency.
 pip install bitdotio
 ```
 
-2. If you already have Postgres installed, you can install with the psycopg2 depedency:
+2. If you already have Postgres installed, you can install with the psycopg2 dependency:
 ```
 pip install bitdotio[psycopg2]
 ```

--- a/README.md
+++ b/README.md
@@ -22,13 +22,30 @@ pprint(cur.fetchone())
 
 # Requirements
 
-`bitdotio` requires a local installation of PostgreSQL, version 12 or greater. This is because the 
-underlying connection management library is `psycopg2` which links against the PostgreSQL library. 
+In order to support different environments, we have a few ways to install the bitdotio package
+with or without the `psycopg2` dependency.
+
+1. If you already have `psycopg2` installed, you can install the default bitdotio package:
+```
+pip install bitdotio
+```
+
+2. If you already have Postgres installed, you can install with the psycopg2 depedency:
+```
+pip install bitdotio[psycopg2]
+```
+
+3. If you do not have or cannot install Postgres, you can install with the psycopg2-binary dependency:
+```
+pip install bitdotio[psycopg2-binary]
+```
+
+## Install Postgres
 
 To install Postgres on Windows, go to https://www.postgresql.org/download/ and download the version
 that is correct for your computer, or use your operating system's preferred package manager.
 
-After you have Postgres installed you can install this library with `pip install bitdotio`.
+After you have Postgres installed you can install this library with `pip install bitdotio[psycopg2]`.
 
 
 # Usage

--- a/bitdotio/bitdotio.py
+++ b/bitdotio/bitdotio.py
@@ -6,30 +6,6 @@ from bitdotio import Configuration, ApiClient, ApiBitdotio
 from bitdotio.rest import ApiException
 from pprint import pprint
 
-try:
-    import psycopg2
-except ImportError:
-    print("""
-It looks like we couldn't import the psycopg2 library!
-
-In order to support different environments, we have a few ways to install the bitdotio package
-with or without the psycopg2 dependency.
-
-1. If you already have psycopg2 install, you can install the default bitdotio package:
-
-  pip install bitdotio
-
-2. If you already have Postgres installed, you can install with the psycopg2 depedency:
-
-  pip install bitdotio[psycopg2]
-
-3. If you do not have or cannot install Postgres, you can install with the psycopg2-binary dependency:
-
-  pip install bitdotio[psycopg2-binary]
-""")
-    exit(1)
-
-
 def bitdotio(access_token):
     return _Bit(access_token)
 
@@ -57,7 +33,34 @@ class _Bit(ApiBitdotio):
         return f"dbname={db} user={user} password={password} host={host} port={port}"
 
     def get_connection(self):
+        try:
+            import psycopg2
+        except ImportError:
+            _print_psycopg2_message()
+            return None
+
         conn_str = self._token_to_creds()
         conn = psycopg2.connect(self._token_to_creds())
         conn.autocommit = True
         return conn
+
+
+def _print_psycopg2_message():
+    print("""
+It looks like we couldn't import the psycopg2 library!
+
+In order to support different environments, we have a few ways to install the bitdotio package
+with or without the psycopg2 dependency.
+
+1. If you already have psycopg2 install, you can install the default bitdotio package:
+
+  pip install bitdotio
+
+2. If you already have Postgres installed, you can install with the psycopg2 depedency:
+
+  pip install bitdotio[psycopg2]
+
+3. If you do not have or cannot install Postgres, you can install with the psycopg2-binary dependency:
+
+  pip install bitdotio[psycopg2-binary]
+""")

--- a/bitdotio/bitdotio.py
+++ b/bitdotio/bitdotio.py
@@ -4,8 +4,30 @@ import time
 import bitdotio
 from bitdotio import Configuration, ApiClient, ApiBitdotio
 from bitdotio.rest import ApiException
-import psycopg2
 from pprint import pprint
+
+try:
+    import psycopg2
+except ImportError:
+    print("""
+It looks like we couldn't import the psycopg2 library!
+
+In order to support different environments, we have a few ways to install the bitdotio package
+with or without the psycopg2 dependency.
+
+1. If you already have psycopg2 install, you can install the default bitdotio package:
+
+  pip install bitdotio
+
+2. If you already have Postgres installed, you can install with the psycopg2 depedency:
+
+  pip install bitdotio[psycopg2]
+
+3. If you do not have or cannot install Postgres, you can install with the psycopg2-binary dependency:
+
+  pip install bitdotio[psycopg2-binary]
+""")
+    exit(1)
 
 
 def bitdotio(access_token):

--- a/bitdotio/bitdotio.py
+++ b/bitdotio/bitdotio.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import print_function
+import sys
 import time
 import bitdotio
 from bitdotio import Configuration, ApiClient, ApiBitdotio
@@ -35,9 +36,9 @@ class _Bit(ApiBitdotio):
     def get_connection(self):
         try:
             import psycopg2
-        except ImportError:
+        except ImportError as e:
             _print_psycopg2_message()
-            return None
+            raise e
 
         conn_str = self._token_to_creds()
         conn = psycopg2.connect(self._token_to_creds())
@@ -56,11 +57,11 @@ with or without the psycopg2 dependency.
 
   pip install bitdotio
 
-2. If you already have Postgres installed, you can install with the psycopg2 depedency:
+2. If you already have Postgres installed, you can install with the psycopg2 dependency:
 
   pip install bitdotio[psycopg2]
 
 3. If you do not have or cannot install Postgres, you can install with the psycopg2-binary dependency:
 
   pip install bitdotio[psycopg2-binary]
-""")
+""", file=sys.stderr)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "bitdotio"
-VERSION = "1.0.0b2"
+VERSION = "1.0.0b3"
 # To install the library, run the following
 #
 # python setup.py install

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ VERSION = "1.0.0b2"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil", "psycopg2 >= 2.8.6"]
+REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil"]
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
@@ -32,6 +32,14 @@ setup(
     url="https://github.com/bitdotioinc/python-bitdotio",
     keywords=["bit.io", "Database", "bit.io Python SDK"],
     install_requires=REQUIRES,
+    extras_require={
+        "psycopg2": [
+            "psycopg2>=2.8.6",
+        ],
+        "psycopg2-binary": [
+            "psycopg2-binary>=2.8.6",
+        ],
+    },
     packages=find_packages(exclude=["test", "tests"]),
     include_package_data=True,
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,14 @@ VERSION = "1.0.0b2"
 # http://pypi.python.org/pypi/setuptools
 
 REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil"]
+EXTRAS = {
+    "psycopg2": [
+        "psycopg2>=2.8.6",
+    ],
+    "psycopg2-binary": [
+        "psycopg2-binary>=2.8.6",
+    ],
+}
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
@@ -32,14 +40,7 @@ setup(
     url="https://github.com/bitdotioinc/python-bitdotio",
     keywords=["bit.io", "Database", "bit.io Python SDK"],
     install_requires=REQUIRES,
-    extras_require={
-        "psycopg2": [
-            "psycopg2>=2.8.6",
-        ],
-        "psycopg2-binary": [
-            "psycopg2-binary>=2.8.6",
-        ],
-    },
+    extras_require=EXTRAS,
     packages=find_packages(exclude=["test", "tests"]),
     include_package_data=True,
     long_description=long_description,


### PR DESCRIPTION
**Sumary:**
Currently we can't install the `bitdotio` package on Deepnote since the `psycopg2` dependency has some build prerequisites that cannot be met.

This PR removes the `psycopg2` dependency from the default installation of the `bitdotio` package and uses the `extras_require` parameter to allow the user to choose which dependency they would like to install, either `psycopg2` if they have Postgres already installed or `psycopg2-binary` which doesn't depend on Postgres.

**Test plan:**
- Tested all the installations (default, psycopg2, psycopg2-binary)

