### PR TITLE
Quotes pip extras for zsh portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ pip install bitdotio
 
 2. If you already have Postgres installed, you can install with the psycopg2 dependency:
 ```
-pip install bitdotio[psycopg2]
+pip install 'bitdotio[psycopg2]'
 ```
 
 3. If you do not have or cannot install Postgres, you can install with the psycopg2-binary dependency:
 ```
-pip install bitdotio[psycopg2-binary]
+pip install 'bitdotio[psycopg2-binary]'
 ```
 
 ## Install Postgres


### PR DESCRIPTION
It seems the existing pip install docs work in bash but not zsh. I am proposing a minor update that works in both shells. This appears consistent with the install instructions for some other popular python packages, although it's a mixed bag.

I have tested the quoted version both in zsh on mac and bash on ubuntu. 