### PR TITLE
README hyperlinks hit live URLS now

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,15 +112,15 @@ setup your endpoints to expire after a certain date or a certain number of uses.
 
 Detailed documentation on interacting with each concept with the SDK:
 
- - [Column](docs/Column.md)
- - [QConnection](docs/QConnection.md)
- - [QEndpoint](docs/QEndpoint.md)
- - [QUser](docs/QUser.md)
- - [QUserProfile](docs/QUserProfile.md)
- - [QueryResult](docs/QueryResult.md)
- - [Repo](docs/Repo.md)
- - [RepoCollaborators](docs/RepoCollaborators.md)
- - [Table](docs/Table.md)
+ - [Column](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/Column.md)
+ - [QConnection](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/QConnection.md)
+ - [QEndpoint](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/QEndpoint.md)
+ - [QUser](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/QUser.md)
+ - [QUserProfile](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/QUserProfile.md)
+ - [QueryResult](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/QueryResult.md)
+ - [Repo](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/Repo.md)
+ - [RepoCollaborators](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/RepoCollaborators.md)
+ - [Table](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/Table.md)
 
 
 
@@ -129,43 +129,43 @@ Detailed documentation on interacting with each concept with the SDK:
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*ApiBitdotio* | [**address_q_connection**](docs/ApiBitdotio.md#address_q_connection) | **GET** /users/{user_username}/connections/{name}/address/ | 
-*ApiBitdotio* | [**address_q_endpoint**](docs/ApiBitdotio.md#address_q_endpoint) | **GET** /users/{user_username}/repos/{repo_name}/endpoints/{name}/address/ | 
-*ApiBitdotio* | [**create_column**](docs/ApiBitdotio.md#create_column) | **POST** /users/{user_username}/repos/{repo_name}/tables/{table_current_name}/columns/ | 
-*ApiBitdotio* | [**create_q_connection**](docs/ApiBitdotio.md#create_q_connection) | **POST** /users/{user_username}/connections/ | 
-*ApiBitdotio* | [**create_q_endpoint**](docs/ApiBitdotio.md#create_q_endpoint) | **POST** /users/{user_username}/repos/{repo_name}/endpoints/ | 
-*ApiBitdotio* | [**create_query_result**](docs/ApiBitdotio.md#create_query_result) | **POST** /query/ | 
-*ApiBitdotio* | [**create_repo**](docs/ApiBitdotio.md#create_repo) | **POST** /users/{user_username}/repos/ | 
-*ApiBitdotio* | [**create_table**](docs/ApiBitdotio.md#create_table) | **POST** /users/{user_username}/repos/{repo_name}/tables/ | 
-*ApiBitdotio* | [**destroy_column**](docs/ApiBitdotio.md#destroy_column) | **DELETE** /users/{user_username}/repos/{repo_name}/tables/{table_current_name}/columns/{current_name}/ | 
-*ApiBitdotio* | [**destroy_q_connection**](docs/ApiBitdotio.md#destroy_q_connection) | **DELETE** /users/{user_username}/connections/{name}/ | 
-*ApiBitdotio* | [**destroy_q_endpoint**](docs/ApiBitdotio.md#destroy_q_endpoint) | **DELETE** /users/{user_username}/repos/{repo_name}/endpoints/{name}/ | 
-*ApiBitdotio* | [**destroy_repo**](docs/ApiBitdotio.md#destroy_repo) | **DELETE** /users/{user_username}/repos/{name}/ | 
-*ApiBitdotio* | [**destroy_table**](docs/ApiBitdotio.md#destroy_table) | **DELETE** /users/{user_username}/repos/{repo_name}/tables/{current_name}/ | 
-*ApiBitdotio* | [**list_columns**](docs/ApiBitdotio.md#list_columns) | **GET** /users/{user_username}/repos/{repo_name}/tables/{table_current_name}/columns/ | 
-*ApiBitdotio* | [**list_q_connections**](docs/ApiBitdotio.md#list_q_connections) | **GET** /users/{user_username}/connections/ | 
-*ApiBitdotio* | [**list_q_endpoints**](docs/ApiBitdotio.md#list_q_endpoints) | **GET** /users/{user_username}/repos/{repo_name}/endpoints/ | 
-*ApiBitdotio* | [**list_q_users**](docs/ApiBitdotio.md#list_q_users) | **GET** /users/ | 
-*ApiBitdotio* | [**list_repos**](docs/ApiBitdotio.md#list_repos) | **GET** /users/{user_username}/repos/ | 
-*ApiBitdotio* | [**list_tables**](docs/ApiBitdotio.md#list_tables) | **GET** /users/{user_username}/repos/{repo_name}/tables/ | 
-*ApiBitdotio* | [**partial_update_column**](docs/ApiBitdotio.md#partial_update_column) | **PATCH** /users/{user_username}/repos/{repo_name}/tables/{table_current_name}/columns/{current_name}/ | 
-*ApiBitdotio* | [**partial_update_q_connection**](docs/ApiBitdotio.md#partial_update_q_connection) | **PATCH** /users/{user_username}/connections/{name}/ | 
-*ApiBitdotio* | [**partial_update_q_endpoint**](docs/ApiBitdotio.md#partial_update_q_endpoint) | **PATCH** /users/{user_username}/repos/{repo_name}/endpoints/{name}/ | 
-*ApiBitdotio* | [**partial_update_q_user**](docs/ApiBitdotio.md#partial_update_q_user) | **PATCH** /users/{username}/ | 
-*ApiBitdotio* | [**partial_update_repo**](docs/ApiBitdotio.md#partial_update_repo) | **PATCH** /users/{user_username}/repos/{name}/ | 
-*ApiBitdotio* | [**partial_update_table**](docs/ApiBitdotio.md#partial_update_table) | **PATCH** /users/{user_username}/repos/{repo_name}/tables/{current_name}/ | 
-*ApiBitdotio* | [**retrieve_column**](docs/ApiBitdotio.md#retrieve_column) | **GET** /users/{user_username}/repos/{repo_name}/tables/{table_current_name}/columns/{current_name}/ | 
-*ApiBitdotio* | [**retrieve_q_connection**](docs/ApiBitdotio.md#retrieve_q_connection) | **GET** /users/{user_username}/connections/{name}/ | 
-*ApiBitdotio* | [**retrieve_q_endpoint**](docs/ApiBitdotio.md#retrieve_q_endpoint) | **GET** /users/{user_username}/repos/{repo_name}/endpoints/{name}/ | 
-*ApiBitdotio* | [**retrieve_q_user**](docs/ApiBitdotio.md#retrieve_q_user) | **GET** /users/{username}/ | 
-*ApiBitdotio* | [**retrieve_repo**](docs/ApiBitdotio.md#retrieve_repo) | **GET** /users/{user_username}/repos/{name}/ | 
-*ApiBitdotio* | [**retrieve_table**](docs/ApiBitdotio.md#retrieve_table) | **GET** /users/{user_username}/repos/{repo_name}/tables/{current_name}/ | 
-*ApiBitdotio* | [**share_repo**](docs/ApiBitdotio.md#share_repo) | **POST** /users/{user_username}/repos/{name}/share/ | 
-*ApiBitdotio* | [**share_table**](docs/ApiBitdotio.md#share_table) | **POST** /users/{user_username}/repos/{repo_name}/tables/{current_name}/share/ | 
-*ApiBitdotio* | [**update_column**](docs/ApiBitdotio.md#update_column) | **PUT** /users/{user_username}/repos/{repo_name}/tables/{table_current_name}/columns/{current_name}/ | 
-*ApiBitdotio* | [**update_q_connection**](docs/ApiBitdotio.md#update_q_connection) | **PUT** /users/{user_username}/connections/{name}/ | 
-*ApiBitdotio* | [**update_q_endpoint**](docs/ApiBitdotio.md#update_q_endpoint) | **PUT** /users/{user_username}/repos/{repo_name}/endpoints/{name}/ | 
-*ApiBitdotio* | [**update_q_user**](docs/ApiBitdotio.md#update_q_user) | **PUT** /users/{username}/ | 
-*ApiBitdotio* | [**update_repo**](docs/ApiBitdotio.md#update_repo) | **PUT** /users/{user_username}/repos/{name}/ | 
-*ApiBitdotio* | [**update_table**](docs/ApiBitdotio.md#update_table) | **PUT** /users/{user_username}/repos/{repo_name}/tables/{current_name}/ | 
+*ApiBitdotio* | [**address_q_connection**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#address_q_connection) | **GET** /users/{user_username}/connections/{name}/address/ | 
+*ApiBitdotio* | [**address_q_endpoint**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#address_q_endpoint) | **GET** /users/{user_username}/repos/{repo_name}/endpoints/{name}/address/ | 
+*ApiBitdotio* | [**create_column**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#create_column) | **POST** /users/{user_username}/repos/{repo_name}/tables/{table_current_name}/columns/ | 
+*ApiBitdotio* | [**create_q_connection**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#create_q_connection) | **POST** /users/{user_username}/connections/ | 
+*ApiBitdotio* | [**create_q_endpoint**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#create_q_endpoint) | **POST** /users/{user_username}/repos/{repo_name}/endpoints/ | 
+*ApiBitdotio* | [**create_query_result**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#create_query_result) | **POST** /query/ | 
+*ApiBitdotio* | [**create_repo**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#create_repo) | **POST** /users/{user_username}/repos/ | 
+*ApiBitdotio* | [**create_table**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#create_table) | **POST** /users/{user_username}/repos/{repo_name}/tables/ | 
+*ApiBitdotio* | [**destroy_column**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#destroy_column) | **DELETE** /users/{user_username}/repos/{repo_name}/tables/{table_current_name}/columns/{current_name}/ | 
+*ApiBitdotio* | [**destroy_q_connection**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#destroy_q_connection) | **DELETE** /users/{user_username}/connections/{name}/ | 
+*ApiBitdotio* | [**destroy_q_endpoint**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#destroy_q_endpoint) | **DELETE** /users/{user_username}/repos/{repo_name}/endpoints/{name}/ | 
+*ApiBitdotio* | [**destroy_repo**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#destroy_repo) | **DELETE** /users/{user_username}/repos/{name}/ | 
+*ApiBitdotio* | [**destroy_table**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#destroy_table) | **DELETE** /users/{user_username}/repos/{repo_name}/tables/{current_name}/ | 
+*ApiBitdotio* | [**list_columns**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#list_columns) | **GET** /users/{user_username}/repos/{repo_name}/tables/{table_current_name}/columns/ | 
+*ApiBitdotio* | [**list_q_connections**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#list_q_connections) | **GET** /users/{user_username}/connections/ | 
+*ApiBitdotio* | [**list_q_endpoints**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#list_q_endpoints) | **GET** /users/{user_username}/repos/{repo_name}/endpoints/ | 
+*ApiBitdotio* | [**list_q_users**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#list_q_users) | **GET** /users/ | 
+*ApiBitdotio* | [**list_repos**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#list_repos) | **GET** /users/{user_username}/repos/ | 
+*ApiBitdotio* | [**list_tables**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#list_tables) | **GET** /users/{user_username}/repos/{repo_name}/tables/ | 
+*ApiBitdotio* | [**partial_update_column**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#partial_update_column) | **PATCH** /users/{user_username}/repos/{repo_name}/tables/{table_current_name}/columns/{current_name}/ | 
+*ApiBitdotio* | [**partial_update_q_connection**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#partial_update_q_connection) | **PATCH** /users/{user_username}/connections/{name}/ | 
+*ApiBitdotio* | [**partial_update_q_endpoint**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#partial_update_q_endpoint) | **PATCH** /users/{user_username}/repos/{repo_name}/endpoints/{name}/ | 
+*ApiBitdotio* | [**partial_update_q_user**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#partial_update_q_user) | **PATCH** /users/{username}/ | 
+*ApiBitdotio* | [**partial_update_repo**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#partial_update_repo) | **PATCH** /users/{user_username}/repos/{name}/ | 
+*ApiBitdotio* | [**partial_update_table**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#partial_update_table) | **PATCH** /users/{user_username}/repos/{repo_name}/tables/{current_name}/ | 
+*ApiBitdotio* | [**retrieve_column**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#retrieve_column) | **GET** /users/{user_username}/repos/{repo_name}/tables/{table_current_name}/columns/{current_name}/ | 
+*ApiBitdotio* | [**retrieve_q_connection**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#retrieve_q_connection) | **GET** /users/{user_username}/connections/{name}/ | 
+*ApiBitdotio* | [**retrieve_q_endpoint**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#retrieve_q_endpoint) | **GET** /users/{user_username}/repos/{repo_name}/endpoints/{name}/ | 
+*ApiBitdotio* | [**retrieve_q_user**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#retrieve_q_user) | **GET** /users/{username}/ | 
+*ApiBitdotio* | [**retrieve_repo**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#retrieve_repo) | **GET** /users/{user_username}/repos/{name}/ | 
+*ApiBitdotio* | [**retrieve_table**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#retrieve_table) | **GET** /users/{user_username}/repos/{repo_name}/tables/{current_name}/ | 
+*ApiBitdotio* | [**share_repo**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#share_repo) | **POST** /users/{user_username}/repos/{name}/share/ | 
+*ApiBitdotio* | [**share_table**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#share_table) | **POST** /users/{user_username}/repos/{repo_name}/tables/{current_name}/share/ | 
+*ApiBitdotio* | [**update_column**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#update_column) | **PUT** /users/{user_username}/repos/{repo_name}/tables/{table_current_name}/columns/{current_name}/ | 
+*ApiBitdotio* | [**update_q_connection**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#update_q_connection) | **PUT** /users/{user_username}/connections/{name}/ | 
+*ApiBitdotio* | [**update_q_endpoint**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#update_q_endpoint) | **PUT** /users/{user_username}/repos/{repo_name}/endpoints/{name}/ | 
+*ApiBitdotio* | [**update_q_user**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#update_q_user) | **PUT** /users/{username}/ | 
+*ApiBitdotio* | [**update_repo**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#update_repo) | **PUT** /users/{user_username}/repos/{name}/ | 
+*ApiBitdotio* | [**update_table**](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/ApiBitdotio.md#update_table) | **PUT** /users/{user_username}/repos/{repo_name}/tables/{current_name}/ | 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "bitdotio"
-VERSION = "1.0.0b3"
+VERSION = "1.0.0b4"
 # To install the library, run the following
 #
 # python setup.py install


### PR DESCRIPTION
Changed `docs/` to `https://github.com/bitdotioinc/python-bitdotio/tree/main/docs/`.

Version is updated on [pypi](https://pypi.org/project/bitdotio/) and links work!