### PR TITLE
Fix psycopg2 imports and warnings

### DIFF
--- a/bitdotio/bitdotio.py
+++ b/bitdotio/bitdotio.py
@@ -4,8 +4,8 @@ import time
 import bitdotio
 from bitdotio import Configuration, ApiClient, ApiBitdotio
 from bitdotio.rest import ApiException
-import psycopg2
 from pprint import pprint
+import sys
 from . import model
 
 
@@ -41,8 +41,36 @@ class _Bit(ApiBitdotio):
         return self.create_query(query=query_obj)
 
     def get_connection(self):
+        try:
+            import psycopg2
+        except ImportError as e:
+            _print_psycopg2_message()
+            raise e
+
         conn_str = self._token_to_creds()
         conn = psycopg2.connect(self._token_to_creds())
         conn.autocommit = True
 
         return conn
+
+
+def _print_psycopg2_message():
+    print("""
+It looks like we couldn't import the psycopg2 library!
+
+In order to support different environments, we have a few ways to install the bitdotio package
+with or without the psycopg2 dependency.
+
+1. If you already have psycopg2 install, you can install the default bitdotio package:
+
+  pip install bitdotio
+
+2. If you already have Postgres installed, you can install with the psycopg2 dependency:
+
+  pip install bitdotio[psycopg2]
+
+3. If you do not have or cannot install Postgres, you can install with the psycopg2-binary dependency:
+
+  pip install bitdotio[psycopg2-binary]
+
+""", file=sys.stderr)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "bitdotio"
-VERSION = "1.0.6b1"
+VERSION = "1.0.7b1"
 # To install the library, run the following
 #
 # python setup.py install
@@ -18,7 +18,16 @@ VERSION = "1.0.6b1"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil", "click >= 8.0.1", "psycopg2-binary >= 2.8.6"]
+REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil", "click >= 8.0.1"]
+
+EXTRAS = {
+    "psycopg2": [
+        "psycopg2>=2.8.6",
+    ],
+    "psycopg2-binary": [
+        "psycopg2-binary>=2.8.6",
+    ],
+}
 
 
 with open("README.md", "r", encoding="utf-8") as fh:
@@ -33,6 +42,7 @@ setup(
     url="https://github.com/bitdotioinc/python-bitdotio",
     keywords=["bit.io", "Database", "bit.io Python SDK"],
     install_requires=REQUIRES,
+    extras_require=EXTRAS,
     packages=find_packages(exclude=["test", "tests"]),
     include_package_data=True,
     long_description=long_description,


### PR DESCRIPTION
A previous generation of the SDK had better handling of `psycopg2` dependency management; this brings that back.