### PR TITLE
Add v2 token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,23 @@
 
 # bitdotio module
 
-Example usage:
+The bit.io Python SDK supports two major versions of bit.io: v1 and v2. 
 
-```
+The v1 SDK is instantiated using a v1 bit.io API token and supports listings repos,
+running queries, and importing data using methods of the SDK object returned by
+the `bitdotio` function. The v1 SDK object can also generate pre-configured `psycopg2`
+connections to v1 bit.io.
+
+The v2 SDK currently only supports generation of pre-configured `psycopg2` connections
+to v2 bit.io. We plan to add further SDK features for v2 based on user feedback. 
+
+Both versions of the SDK are instantiated by calling the `bitdotio` function with
+either a v1 or v2 API token. The version of SDK object returned is based on the
+version of the provided token. 
+
+Example v1 usage:
+
+```python
 #!/usr/bin/env python3
 import bitdotio
 from pprint import pprint
@@ -12,6 +26,7 @@ from pprint import pprint
 # Connect to bit.io
 b = bitdotio.bitdotio(<YOUR_API_KEY>)
 
+# List repos
 pprint(b.list_repos())
 
 # How about some database queries?
@@ -21,6 +36,26 @@ cur.execute("SELECT 1")
 pprint(cur.fetchone())
 ```
 
+Example v2 usage:
+```python
+#!/usr/bin/env python3
+import bitdotio
+from pprint import pprint
+
+# Connect to bit.io
+b = bitdotio.bitdotio(<YOUR_API_KEY>)
+
+# List repos
+pprint(b.list_repos())
+
+# How about some database queries?
+# NOTE: v2 connections require specification of the database name, because
+# v2 bit.io is built around independent user databases, not repos (schemas) on a single database.
+conn = b.get_connection(<YOUR_DATABASE_NAME>)
+cur = conn.cursor()
+cur.execute("SELECT 1")
+pprint(cur.fetchone())
+```
 
 ## Requirements
 
@@ -63,7 +98,7 @@ See https://docs.bit.io/docs/connecting-to-bitio screenshots and examples.
 
 `bitdotio` provides easy Python access to querying your data with just a bit.io API key:
 
-```
+```python
 #!/usr/bin/env python3
 import bitdotio
 
@@ -71,6 +106,7 @@ import bitdotio
 b = bitdotio.bitdotio(<YOUR_API_KEY>)
 
 conn = b.get_connection()
+# for v2: conn = b.get_connection(<YOUR_DATABASE_NAME>)
 cur = conn.cursor()
 cur.execute("SELECT 1")
 print(cur.fetchone())
@@ -78,35 +114,13 @@ print(cur.fetchone())
 
 The connection and cursor provided by `bitdotio` are fully Python DB-API compatible, are in fact Pyscopg2 connections and cursors.
 
-Full documentation on Psycopg2 can be found on https://www.psycopg.org/docs/usage.html
+Full documentation on Psycopg2 can be found on https://www.psycopg.org/docs/usage.html.
 
-
-### bitdotio usage
-
-`bitdotio` can also do almost everything you can do on bit.io's main site.
-
-```
-#!/usr/bin/env python3
-import bitdotio
-from pprint import pprint
-
-# Connect to bit.io
-b = bitdotio.bitdotio(<YOUR_API_KEY>)
-
-# Let's see your repos
-pprint(b.list_repos())
-```
-
-You can use the SDK to create/update/delete repos and query data. In general the SDK is fully mapped to the REST API;
-the documentation for the REST API is availble at https://docs.bit.io/reference
-
-
-# bit.io concepts
+# v1 bit.io concepts
 
 bit.io is a database, with extra features like easy sharing and collaboration. We have a few concepts that the SDK works with:
 
-* Repostories ("repos") - a schema, in Postgres terms, that contains tables and columns. You can have public and private repositories, and you can write SQL that joins
-any repo you have access to with another repo. A repo contains tables, and tables contain columns.
+* Repostories ("repos") - a schema, in Postgres terms, that contains tables and columns. You can have public and private repositories, and you can write SQL that joins any repo you have access to with another repo. A repo contains tables, and tables contain columns.
 
 Detailed documentation on interacting with each concept with the SDK:
 
@@ -114,16 +128,15 @@ Detailed documentation on interacting with each concept with the SDK:
  - [Repo](https://github.com/bitdotioinc/python-bitdotio/blob/main/docs/Repo.md)
 
 
-# bit.io CLI usage
+# v1 bit.io CLI usage
 
-
-Installing the bitdotio module also installs the command line tool `bit` which lets you interact with bit.io
+Installing the bitdotio module also installs the command line tool `bit` which lets you interact with v1 bit.io
 from scripts or the command line. This is installed next to your python binary.
 
 You'll want to grab your API key from your bit.io account - to get the key, log into to bit.io and
 click on the green "Connect" button, and copy the API key.
 
-
+Note: v2 bit.io doesn't have a CLI yet. The CLI will not work with v2 bit.io tokens.
 
 ```
 Usage: bit [OPTIONS] COMMAND [ARGS]...

--- a/bitdotio/bitdotio.py
+++ b/bitdotio/bitdotio.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import print_function
+from inspect import Attribute
 import time
 import bitdotio
 from bitdotio import Configuration, ApiClient, ApiBitdotio
@@ -10,11 +11,22 @@ from . import model
 
 
 def bitdotio(access_token):
-    return _Bit(access_token)
+    # determine bit.io version from the token format
+    token_parts = access_token.split('_')
+    if len(token_parts) == 2:
+        return _Bit(access_token)
+    elif (len(token_parts) == 3) and (token_parts[0] == 'v2'):
+        return _BitV2(access_token)
+    else:
+        raise ValueError("Invalid access token format.")
 
-class _Bit(ApiBitdotio):
+
+class _HostConfigMixin():
     _port = 5432
     _host = "db.bit.io"
+
+
+class _Bit(_HostConfigMixin, ApiBitdotio):
     def __init__(self, access_token):
         assert access_token
         configuration = Configuration(
@@ -25,6 +37,9 @@ class _Bit(ApiBitdotio):
         self.api_client = ApiClient(configuration)
         self.api_client.user_agent = "bit.io-SDK/1.0.0/python"
         super().__init__(self.api_client)
+
+    def __repr__(self):
+        return "<bitdotio SDK object: v1>"
 
     def _token_to_creds(self):
         # Both _user_ and _db_ here are to satisfy psycopg2, but bit.io itself
@@ -48,11 +63,63 @@ class _Bit(ApiBitdotio):
             raise e
 
         conn_str = self._token_to_creds()
-        conn = psycopg2.connect(self._token_to_creds())
+        conn = psycopg2.connect(conn_str)
         conn.autocommit = True
 
         return conn
 
+
+class _BitV2(_HostConfigMixin):
+    _BACKWARDS_INCOMPATIBLE_ATTRIBUTES = [
+        'api_client',
+        'create_import_file',
+        'create_import_json',
+        'create_import_url',
+        'create_query',
+        'create_repo',
+        'destroy_repo',
+        'get_connection',
+        'list_repos',
+        'partial_update_repo',
+        'query',
+        'retrieve_ingestor_job',
+        'retrieve_repo',
+        'update_repo',
+        ]
+    
+    def __init__(self, access_token):
+        assert access_token
+        self.access_token = access_token
+
+    def __repr__(self):
+        return "<bitdotio SDK object: v2>"
+
+    # inform user when an attempt is made to access v1-only attribute 
+    def __getattr__(self, name):
+        if name in self._BACKWARDS_INCOMPATIBLE_ATTRIBUTES:
+            raise AttributeError(f"You have configured the SDK with a v2 token, and '{name}' is currently limited to v1.")
+        else:
+            raise AttributeError(f"'_BitV2' object has no attribute '{name}'")
+
+    def _token_to_creds(self, database_name):
+        db = database_name
+        user = "api_user"
+        password = self.access_token
+        host = self._host
+        port = self._port
+        return f"dbname={db} user={user} password={password} host={host} port={port}"
+
+    def get_connection(self, database_name):
+        try:
+            import psycopg2
+        except ImportError as e:
+            _print_psycopg2_message()
+            raise e
+
+        conn_str = self._token_to_creds(database_name)
+        conn = psycopg2.connect(conn_str)
+
+        return conn
 
 def _print_psycopg2_message():
     print("""

--- a/test/test_v2_config.py
+++ b/test/test_v2_config.py
@@ -1,0 +1,47 @@
+import os
+import unittest
+
+import bitdotio
+from bitdotio.bitdotio import _Bit, _BitV2
+
+"""
+Tests automatic SDK configuration based on token version and v1-only attribute messages.
+"""
+
+
+class TestTokenVersionConfig(unittest.TestCase):
+
+    def test_v1_token(self):
+        """Test that v1 formatted token causes v1 object construction"""
+        b = bitdotio.bitdotio("3UPuN_fakeTOKENDDPEBNp7Cux7gy")
+        self.assertIsInstance(b, _Bit)
+
+    def test_v2_token(self):
+        """Test that v2 formatted token causes v2 object construction"""
+        b = bitdotio.bitdotio("v2_5_fakeTOKENWxwNLWZvWCXi6c")
+        self.assertIsInstance(b, _BitV2)
+
+    def test_invalid_token(self):
+        """Test that invalid token format raises value error"""
+        with self.assertRaises(ValueError):
+            b = bitdotio.bitdotio("v2_5_fakeTOKENWx_wNLWZvWCXi6c")
+            self.assertIsInstance(b, _BitV2)    
+
+class TestAttributeMessages(unittest.TestCase):
+    """Test that attempt to access a v1-only attribute causes an attribute error"""
+    def test_v1_only_attribute_with_v2(self):
+        b = bitdotio.bitdotio("v2_5_fakeTOKENWxwNLWZvWCXi6c")
+        with self.assertRaises(AttributeError) as e:
+            b.list_repos()
+        self.assertIn("You have configured the SDK with a v2 token, and", str(e.exception))
+
+    """Test that attempt to access invalid attribute raises normal attribute error"""
+    def test_invalid_attribute_with_v2(self):
+        b = bitdotio.bitdotio("v2_5_fakeTOKENWxwNLWZvWCXi6c")
+        with self.assertRaises(AttributeError) as e:
+            b.fake_method()
+        self.assertIn("'_BitV2' object has no attribute 'fake_method'", str(e.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
- Adds basic v2 token support (get `psycopg2` connection without autocommit using token and db name)
- Adds messages for non-backwards compatible v1 features

Test Plan:
- Manual testing of queries with both v1 and v2 after change
- Added test suite for token format detection logic and missing attribute messages