### PR TITLE
Add connection pooling by default

### DIFF
--- a/bitdotio/__init__.py
+++ b/bitdotio/__init__.py
@@ -2,4 +2,4 @@
 
 __version__ = "1.0.0"
 
-from bitdotio.bitdotio import bitdotio
+from bitdotio._bitdotio import bitdotio

--- a/bitdotio/_bitdotio.py
+++ b/bitdotio/_bitdotio.py
@@ -89,6 +89,28 @@ class _BitV2:
         port = self._port
         return f"dbname={db} user={user} password={password} host={host} port={port} sslmode=require"
 
+    def _get_pool(self, db_name: str):
+        pool = self._pools.get(db_name)
+        if pool is not None:
+            return pool
+
+        try:
+            # Threadsafe by default
+            # TODO: do we care about supporting SimpleConnectionPool?
+            from psycopg2.pool import ThreadedConnectionPool
+        except ImportError as exc:
+            _print_psycopg2_message()
+            raise exc
+
+        conn_string = self._get_conn_string(db_name)
+        pool = ThreadedConnectionPool(
+            self._min_conn,
+            self._max_conn,
+            conn_string,
+        )
+        self._pools[db_name] = pool
+        return pool
+
     @deprecated(
         "The get_connection() interface is deprecated and will be removed in a future vestion of the bit.io python SDK. Please use the connect() and cursor() interfaces."
     )
@@ -108,26 +130,9 @@ class _BitV2:
     def connect(self, db_name: str):
         pool, conn = None, None
         try:
-            pool = self._pools.get(db_name)
-            if pool is None:
-                try:
-                    # Threadsafe by default
-                    # TODO: do we care about supporting SimpleConnectionPool?
-                    from psycopg2.pool import ThreadedConnectionPool
-                except ImportError as exc:
-                    _print_psycopg2_message()
-                    raise exc
-
-                conn_string = self._get_conn_string(db_name)
-                pool = ThreadedConnectionPool(
-                    self._min_conn,
-                    self._max_conn,
-                    conn_string,
-                )
-                self._pools[db_name] = pool
-
-                conn = pool.getconn()
-                yield conn
+            pool = self._get_pool(db_name)
+            conn = pool.getconn()
+            yield conn
         finally:
             if pool is not None and conn is not None:
                 pool.putconn(conn)

--- a/bitdotio/_bitdotio.py
+++ b/bitdotio/_bitdotio.py
@@ -127,7 +127,7 @@ class _BitV2:
         return conn
 
     @contextmanager
-    def connect(self, db_name: str):
+    def pooled_connection(self, db_name: str):
         pool, conn = None, None
         try:
             pool = self._get_pool(db_name)
@@ -138,8 +138,8 @@ class _BitV2:
                 pool.putconn(conn)
 
     @contextmanager
-    def cursor(self, db_name: str):
-        with self.connect(db_name) as conn:
+    def pooled_cursor(self, db_name: str):
+        with self.pooled_connection(db_name) as conn:
             with conn.cursor() as cursor:
                 yield cursor
 

--- a/bitdotio/_bitdotio.py
+++ b/bitdotio/_bitdotio.py
@@ -3,17 +3,11 @@ import functools
 import sys
 import typing as t
 from contextlib import contextmanager
-from warnings import warn
 
 from requests import Response
 
 from bitdotio.api_client import ApiClient
-from bitdotio.utils import (
-    deprecated,
-    validate_database_name,
-    validate_min_max_conn,
-    validate_token,
-)
+from bitdotio.utils import validate_database_name, validate_min_max_conn, validate_token
 
 API_VERSION = "v2beta"
 
@@ -120,9 +114,6 @@ class _BitV2:
         self._pools[db_name] = pool
         return pool
 
-    @deprecated(
-        "The get_connection() interface is deprecated and will be removed in a future vestion of the bit.io python SDK. Please use the connect() and cursor() interfaces."
-    )
     def get_connection(self, db_name):
         try:
             import psycopg2

--- a/bitdotio/_bitdotio.py
+++ b/bitdotio/_bitdotio.py
@@ -89,6 +89,14 @@ class _BitV2:
         port = self._port
         return f"dbname={db} user={user} password={password} host={host} port={port} sslmode=require"
 
+    @staticmethod
+    def _create_pool(pool_cls, *args, **kwargs):
+        """This is super weird code factorization but it's necessary in order to mock
+        out the connection pool in testing. We can't mock ThreadedConnectionPool
+        directly since it's not imported at the module level.
+        """
+        return pool_cls(*args, **kwargs)
+
     def _get_pool(self, db_name: str):
         pool = self._pools.get(db_name)
         if pool is not None:
@@ -103,7 +111,8 @@ class _BitV2:
             raise exc
 
         conn_string = self._get_conn_string(db_name)
-        pool = ThreadedConnectionPool(
+        pool = self._create_pool(
+            ThreadedConnectionPool,
             self._min_conn,
             self._max_conn,
             conn_string,

--- a/bitdotio/bitdotio.py
+++ b/bitdotio/bitdotio.py
@@ -2,11 +2,12 @@
 import functools
 import sys
 import typing as t
+from contextlib import contextmanager
 
 from requests import Response
 
 from bitdotio.api_client import ApiClient
-from bitdotio.utils import validate_database_name, validate_token
+from bitdotio.utils import validate_database_name, validate_min_max_conn, validate_token
 
 API_VERSION = "v2beta"
 
@@ -14,8 +15,10 @@ API_VERSION = "v2beta"
 def bitdotio(
     access_token: str,
     api_version: str = API_VERSION,
+    min_conn: int = 0,
+    max_conn: int = 100,
 ):
-    return _BitV2(access_token, api_version)
+    return _BitV2(access_token, api_version, min_conn, max_conn)
 
 
 class ApiError(Exception):
@@ -52,34 +55,79 @@ class _BitV2:
     _port = 5432
     _host = "db.bit.io"
 
-    def __init__(self, access_token: str, api_version: str) -> None:
+    def __init__(
+        self,
+        access_token: str,
+        api_version: str,
+        min_conn: int,
+        max_conn: int,
+    ) -> None:
         validate_token(access_token)
+        validate_min_max_conn(min_conn, max_conn)
 
         self._access_token = access_token
         self._api_client = ApiClient(access_token, api_version)
+        self._min_conn = min_conn
+        self._max_conn = max_conn
+
+        self._pools = {}
 
     def __repr__(self):
         return "<bitdotio SDK object: v2>"
 
-    def _token_to_creds(self, database_name):
-        db = database_name
+    def _get_conn_string(self, db_name):
+        db = db_name
         user = "api_user"
         password = self._access_token
         host = self._host
         port = self._port
         return f"dbname={db} user={user} password={password} host={host} port={port} sslmode=require"
 
-    def get_connection(self, database_name):
+    def get_connection(self, db_name):
         try:
             import psycopg2
         except ImportError as e:
             _print_psycopg2_message()
             raise e
 
-        conn_str = self._token_to_creds(database_name)
+        conn_str = self._get_conn_string(db_name)
         conn = psycopg2.connect(conn_str)
 
         return conn
+
+    @contextmanager
+    def connect(self, db_name: str):
+        pool, conn = None, None
+        try:
+            pool = self._pools.get(db_name)
+            if pool is None:
+                try:
+                    # Threadsafe by default
+                    # TODO: do we care about supporting SimpleConnectionPool?
+                    from psycopg2.pool import ThreadedConnectionPool
+                except ImportError as exc:
+                    _print_psycopg2_message()
+                    raise exc
+
+                conn_string = self._get_conn_string(db_name)
+                pool = ThreadedConnectionPool(
+                    self._min_conn,
+                    self._max_conn,
+                    conn_string,
+                )
+                self._pools[db_name] = pool
+
+                conn = pool.getconn()
+                yield conn
+        finally:
+            if pool is not None and conn is not None:
+                pool.putconn(conn)
+
+    @contextmanager
+    def cursor(self, db_name: str):
+        with self.connect(db_name) as conn:
+            with conn.cursor() as cursor:
+                yield cursor
 
     @api_method(returning="databases")
     def list_databases(self):

--- a/bitdotio/bitdotio.py
+++ b/bitdotio/bitdotio.py
@@ -3,11 +3,17 @@ import functools
 import sys
 import typing as t
 from contextlib import contextmanager
+from warnings import warn
 
 from requests import Response
 
 from bitdotio.api_client import ApiClient
-from bitdotio.utils import validate_database_name, validate_min_max_conn, validate_token
+from bitdotio.utils import (
+    deprecated,
+    validate_database_name,
+    validate_min_max_conn,
+    validate_token,
+)
 
 API_VERSION = "v2beta"
 
@@ -83,6 +89,9 @@ class _BitV2:
         port = self._port
         return f"dbname={db} user={user} password={password} host={host} port={port} sslmode=require"
 
+    @deprecated(
+        "The get_connection() interface is deprecated and will be removed in a future vestion of the bit.io python SDK. Please use the connect() and cursor() interfaces."
+    )
     def get_connection(self, db_name):
         try:
             import psycopg2

--- a/bitdotio/utils.py
+++ b/bitdotio/utils.py
@@ -1,4 +1,6 @@
+import functools
 import re
+import warnings
 
 
 _RE_TOKEN = re.compile(r"^v2_\w+$")
@@ -17,6 +19,24 @@ def validate_database_name(db_name: str):
 
 def validate_min_max_conn(min_conn: int, max_conn: int):
     if min_conn < 0 or max_conn < 0:
-        raise ValueError("min_conn and max_conn must both be greater than or equal to zero")
+        raise ValueError(
+            "min_conn and max_conn must both be greater than or equal to zero"
+        )
     if min_conn >= max_conn:
         raise ValueError("min_conn must be strictly less than max_conn")
+
+
+class _DeprecationWarning(UserWarning):
+    pass
+
+
+def deprecated(msg: str):
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            warnings.warn(msg, _DeprecationWarning, stacklevel=2)
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/bitdotio/utils.py
+++ b/bitdotio/utils.py
@@ -13,3 +13,10 @@ def validate_token(token: str):
 def validate_database_name(db_name: str):
     if _RE_DB_NAME.fullmatch(db_name) is None:
         raise ValueError("Invalid database name")
+
+
+def validate_min_max_conn(min_conn: int, max_conn: int):
+    if min_conn < 0 or max_conn < 0:
+        raise ValueError("min_conn and max_conn must both be greater than or equal to zero")
+    if min_conn >= max_conn:
+        raise ValueError("min_conn must be strictly less than max_conn")

--- a/bitdotio/utils.py
+++ b/bitdotio/utils.py
@@ -1,6 +1,4 @@
-import functools
 import re
-import warnings
 
 
 _RE_TOKEN = re.compile(r"^v2_\w+$")
@@ -19,24 +17,6 @@ def validate_database_name(db_name: str):
 
 def validate_min_max_conn(min_conn: int, max_conn: int):
     if min_conn < 0 or max_conn < 0:
-        raise ValueError(
-            "min_conn and max_conn must both be greater than or equal to zero"
-        )
+        raise ValueError("min_conn and max_conn must both be greater than or equal to zero")
     if min_conn >= max_conn:
         raise ValueError("min_conn must be strictly less than max_conn")
-
-
-class _DeprecationWarning(UserWarning):
-    pass
-
-
-def deprecated(msg: str):
-    def decorator(fn):
-        @functools.wraps(fn)
-        def wrapper(*args, **kwargs):
-            warnings.warn(msg, _DeprecationWarning, stacklevel=2)
-            return fn(*args, **kwargs)
-
-        return wrapper
-
-    return decorator

--- a/test/test_api_client.py
+++ b/test/test_api_client.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 from bitdotio.api_client import ApiClient
-from bitdotio.bitdotio import API_VERSION
+from bitdotio._bitdotio import API_VERSION
 
 
 class TestApiClient(unittest.TestCase):

--- a/test/test_api_methods.py
+++ b/test/test_api_methods.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 from bitdotio import bitdotio
-from bitdotio.bitdotio import ApiError
+from bitdotio._bitdotio import ApiError
 
 
 class TestApiMethods(unittest.TestCase):

--- a/test/test_connect.py
+++ b/test/test_connect.py
@@ -21,7 +21,7 @@ class TestConnect(unittest.TestCase):
     @patch("bitdotio._bitdotio._BitV2._create_pool")
     def test_connect(self, mock_create_pool: Mock) -> None:
         db_1, db_2 = "my/db1", "my/db2"
-        with self.b.connect(db_1):
+        with self.b.pooled_connection(db_1):
             pass
 
         # get/put should be called and there should be one pool after connecting once
@@ -31,7 +31,7 @@ class TestConnect(unittest.TestCase):
 
         mock_create_pool.return_value.getconn.reset_mock()
         mock_create_pool.return_value.putconn.reset_mock()
-        with self.b.connect(db_1):
+        with self.b.pooled_connection(db_1):
             pass
 
         # get/put should be called and there should be one pool after connecting to the
@@ -42,7 +42,7 @@ class TestConnect(unittest.TestCase):
 
         mock_create_pool.return_value.getconn.reset_mock()
         mock_create_pool.return_value.putconn.reset_mock()
-        with self.b.connect(db_2):
+        with self.b.pooled_connection(db_2):
             pass
 
         # get/put should be called and there should be two pools after connecting to
@@ -54,7 +54,7 @@ class TestConnect(unittest.TestCase):
     @patch("bitdotio._bitdotio._BitV2._create_pool")
     def test_cursor(self, mock_create_pool: Mock) -> None:
         db_1, db_2 = "my/db1", "my/db2"
-        with self.b.cursor(db_1):
+        with self.b.pooled_cursor(db_1):
             pass
 
         # get/put should be called and there should be one pool after connecting once
@@ -64,7 +64,7 @@ class TestConnect(unittest.TestCase):
 
         mock_create_pool.return_value.getconn.reset_mock()
         mock_create_pool.return_value.putconn.reset_mock()
-        with self.b.cursor(db_1):
+        with self.b.pooled_cursor(db_1):
             pass
 
         # get/put should be called and there should be one pool after connecting to the
@@ -75,7 +75,7 @@ class TestConnect(unittest.TestCase):
 
         mock_create_pool.return_value.getconn.reset_mock()
         mock_create_pool.return_value.putconn.reset_mock()
-        with self.b.cursor(db_2):
+        with self.b.pooled_cursor(db_2):
             pass
 
         # get/put should be called and there should be two pools after connecting to

--- a/test/test_connect.py
+++ b/test/test_connect.py
@@ -1,0 +1,85 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from bitdotio import bitdotio
+
+
+class TestConnect(unittest.TestCase):
+    token = "v2_testtoken"
+
+    def setUp(self) -> None:
+        self.b = bitdotio(self.token)
+
+    def test_min_max_conn_validation(
+        self,
+    ) -> None:
+        test_cases = [(-1, 0), (0, -1), (0, 0), (1, 0)]
+        for min_conn, max_conn in test_cases:
+            with self.assertRaises(ValueError):
+                bitdotio(self.token, min_conn=min_conn, max_conn=max_conn)
+
+    @patch("bitdotio._bitdotio._BitV2._create_pool")
+    def test_connect(self, mock_create_pool: Mock) -> None:
+        db_1, db_2 = "my/db1", "my/db2"
+        with self.b.connect(db_1):
+            pass
+
+        # get/put should be called and there should be one pool after connecting once
+        self.assertEqual(len(self.b._pools), 1)
+        mock_create_pool.return_value.getconn.assert_called_once()
+        mock_create_pool.return_value.putconn.assert_called_once()
+
+        mock_create_pool.return_value.getconn.reset_mock()
+        mock_create_pool.return_value.putconn.reset_mock()
+        with self.b.connect(db_1):
+            pass
+
+        # get/put should be called and there should be one pool after connecting to the
+        # same database the second time.
+        self.assertEqual(len(self.b._pools), 1)
+        mock_create_pool.return_value.getconn.assert_called_once()
+        mock_create_pool.return_value.putconn.assert_called_once()
+
+        mock_create_pool.return_value.getconn.reset_mock()
+        mock_create_pool.return_value.putconn.reset_mock()
+        with self.b.connect(db_2):
+            pass
+
+        # get/put should be called and there should be two pools after connecting to
+        # the second database.
+        self.assertEqual(len(self.b._pools), 2)
+        mock_create_pool.return_value.getconn.assert_called_once()
+        mock_create_pool.return_value.putconn.assert_called_once()
+
+    @patch("bitdotio._bitdotio._BitV2._create_pool")
+    def test_cursor(self, mock_create_pool: Mock) -> None:
+        db_1, db_2 = "my/db1", "my/db2"
+        with self.b.cursor(db_1):
+            pass
+
+        # get/put should be called and there should be one pool after connecting once
+        self.assertEqual(len(self.b._pools), 1)
+        mock_create_pool.return_value.getconn.assert_called_once()
+        mock_create_pool.return_value.putconn.assert_called_once()
+
+        mock_create_pool.return_value.getconn.reset_mock()
+        mock_create_pool.return_value.putconn.reset_mock()
+        with self.b.cursor(db_1):
+            pass
+
+        # get/put should be called and there should be one pool after connecting to the
+        # same database the second time.
+        self.assertEqual(len(self.b._pools), 1)
+        mock_create_pool.return_value.getconn.assert_called_once()
+        mock_create_pool.return_value.putconn.assert_called_once()
+
+        mock_create_pool.return_value.getconn.reset_mock()
+        mock_create_pool.return_value.putconn.reset_mock()
+        with self.b.cursor(db_2):
+            pass
+
+        # get/put should be called and there should be two pools after connecting to
+        # the second database.
+        self.assertEqual(len(self.b._pools), 2)
+        mock_create_pool.return_value.getconn.assert_called_once()
+        mock_create_pool.return_value.putconn.assert_called_once()


### PR DESCRIPTION
- Add `connect` and `cursor` methods to `_BitV2` as the new preferred interface for connecting to a database. Both use threadsafe connection pooling by default under the hood.
- Add a deprecation warning to the `get_connection` method