### PR TITLE
Add support for file imports >2 GiB

### DIFF
--- a/bitdotio/_bitdotio.py
+++ b/bitdotio/_bitdotio.py
@@ -236,8 +236,8 @@ class _BitV2:
         if file is not None:
             data = MultipartEncoder(
                 fields={
-                    'file': (table_name, file),
                     **data,
+                    'file': (table_name, file),
                 }
             )
             headers["Content-Type"] = data.content_type

--- a/bitdotio/_bitdotio.py
+++ b/bitdotio/_bitdotio.py
@@ -5,6 +5,7 @@ import typing as t
 from contextlib import contextmanager
 
 from requests import Response
+from requests_toolbelt import MultipartEncoder
 
 from bitdotio.api_client import ApiClient
 from bitdotio.utils import (
@@ -226,12 +227,27 @@ class _BitV2:
             }
         )
 
-        files = {}
+        # Python<3.10 is limited to 2 GiB multi-part encoded files when using
+        # SSL. requests_toolbelt.MultipartEncoder is a workaround for that
+        # limitation. We can remove this workaround later if we drop Python<=3.9.
+        # Refs: https://github.com/psf/requests/issues/2717
+        #       https://bugs.python.org/issue42853
+        headers = {}
         if file is not None:
-            files["file"] = file
+            data = MultipartEncoder(
+                fields={
+                    'file': (table_name, file),
+                    **data,
+                }
+            )
+            headers["Content-Type"] = data.content_type
 
-        return self._api_client.post(f"/db/{db_name}/import/", data=data, files=files)
-
+        return self._api_client.post(
+            f"/db/{db_name}/import/",
+            data=data,
+            headers=headers,
+        )
+        
     @api_method()
     def get_import_job(self, import_id: str):
         return self._api_client.get(f"/import/{import_id}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click >= 8.0.1
 psycopg2 >= 2.8.6
 requests >= 2.28.1
+requests-toolbelt >= 0.10.1

--- a/test/test_api_methods.py
+++ b/test/test_api_methods.py
@@ -1,7 +1,9 @@
 import io
 import unittest
 import uuid
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, ANY
+
+from requests_toolbelt import MultipartEncoder
 
 from bitdotio import bitdotio
 from bitdotio._bitdotio import ApiError
@@ -180,18 +182,32 @@ class TestApiMethods(ApiTestCase):
 
 
 class TestImports(ApiTestCase):
+    @patch("requests_toolbelt.multipart.encoder.uuid4")
     @patch("bitdotio.api_client.ApiClient.request")
-    def test_create_import_job_file_ok(self, mock_request: Mock) -> None:
+    def test_create_import_job_file_ok(self, mock_request: Mock, mock_uuid4: Mock) -> None:
+        mock_uuid4.return_value = uuid.uuid4()
+
         file = io.BytesIO(b"foo")
         mock_request.return_value.ok = True
         mock_request.return_value.json.return_value = {"foo": "bar"}
         self.b.create_import_job("my/db", "table", infer_header="first_row", file=file)
+        data = {"table_name": "table", "infer_header": "first_row"}
+        data = MultipartEncoder(
+            fields={
+                'file': (data["table_name"], file),
+                **data,
+            }
+        )
         mock_request.assert_called_once_with(
             "POST",
             "/db/my/db/import/",
             json=None,
-            data={"table_name": "table", "infer_header": "first_row"},
-            files={"file": file},
+            data=ANY,
+            headers={"Content-Type": data.content_type}
+        )
+        self.assertEqual(
+            data.fields,
+            mock_request.call_args.kwargs["data"].fields,
         )
 
     @patch("bitdotio.api_client.ApiClient.request")
@@ -205,7 +221,7 @@ class TestImports(ApiTestCase):
             "/db/my/db/import/",
             json=None,
             data={"table_name": "table", "schema_name": "schema", "file_url": url},
-            files={},
+            headers={},
         )
 
     @patch("bitdotio.api_client.ApiClient.request")


### PR DESCRIPTION
Adding workaround recommended by `requests` maintainers for `POST`ing files >2GiB ([Ref](https://requests.readthedocs.io/en/latest/user/quickstart/#post-a-multipart-encoded-file))

Tests have been updated. 