### PR TITLE
CLI: Add --verison flag

### DIFF
--- a/bit/bit.py
+++ b/bit/bit.py
@@ -30,6 +30,7 @@ class IgnoreRequiredWithHelp(click.Group):
 
 
 @click.group(cls=IgnoreRequiredWithHelp)
+@click.version_option(__version__, '-v', '--version', is_flag=True, help="Print bit version and exit")
 @click.option(
     "-k",
     "--key",

--- a/bit/bit.py
+++ b/bit/bit.py
@@ -29,8 +29,8 @@ class IgnoreRequiredWithHelp(click.Group):
             return super().parse_args(ctx, ["-k", "v2_help", "--help"])
 
 
-@click.group(cls=IgnoreRequiredWithHelp)
 @click.version_option(__version__, '-v', '--version', is_flag=True, help="Print bit version and exit")
+@click.group(cls=IgnoreRequiredWithHelp)
 @click.option(
     "-k",
     "--key",


### PR DESCRIPTION
See title. Users should be able to query the bit CLI directly for the current CLI/SDK version that is installed.